### PR TITLE
gc.c with max cost

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -302,7 +302,7 @@ static int get_victim_by_default(struct f2fs_sb_info *sbi,
 
 		if (min_cost1 < cost) {
 			p.min_segno = segno;
-			min_cost1 = cost;
+			min_cost1 = cost; // to save maximum cost segment
 		} else if (unlikely(cost == max_cost)) {
 			continue;
 		}


### PR DESCRIPTION
For trial policy we should store maximum cost segment rather than minimum cost segment.
